### PR TITLE
ignored PYL-W0613 as it is not applyable.

### DIFF
--- a/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/HistogramAnalysis.py
+++ b/source/root/usr/lib/logdata-anomaly-miner/aminer/analysis/HistogramAnalysis.py
@@ -88,6 +88,7 @@ class BinDefinition(object):
     at index 1."""
     raise Exception(self.not_implemented)
 
+  # skipcq: PYL-W0613
   def get_bin_p_value(self, bin_pos, total_values, bin_values):
     """Calculate a p-Value, how likely the observed number of
     elements in this bin is.


### PR DESCRIPTION
ModuloTimeBinDefinition does not define get_bin_p_value and the interface should return None by default.